### PR TITLE
Use tokenizer for commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -54,11 +54,11 @@ No tasks to display.
 
 | Command |Format |
 | --- | --- |
-|add|`add <task_name> [st/<start> end/<end> | dl/<deadline>] [t/<tags>]  [r/<recurrence>] [desc/<description>]`|
+|add|`add <task_name> [st/<start> end/<end> | dl/<deadline>] [#<tags>]  [r/<recurrence>] [desc/<description>]`|
 |list|`list [[[after/<date>] [before/<date>] | [on/<date>]][tags=<comma_separated_tags>] [recurrence=<recurrence_value>] [desc=<description_value>]]`|
-|tag|`tag <task_id> <tag_name> [, <tag_name> …]`|
-|untag|`untag <task_id> <tag_name> [, <tag_name> …]`|
-|edit|`edit <task_id> [new title] [st/ <start> end/ <end> | deadline/ <deadline>] [t/ <tags>...] [r/ <recurrence>] [desc/ <description>]`|
+|tag|`tag <task_id> #<tag_name> [#<tag_name> …]`|
+|untag|`untag <task_id> #<tag_name> [#<tag_name> …]`|
+|edit|`edit <task_id> [title/ new title] [st/ <start> end/ <end> | deadline/ <deadline>] [t/ <tags>...] [r/ <recurrence>] [desc/ <description>]`|
 |delete|`delete <task_id>`|
 |mark|`mark <task_id>`|
 |unmark|`unmark <task_id>`|
@@ -69,7 +69,7 @@ No tasks to display.
 ## Commands
 
 ```
-add <task_name> [st/<start> end/<end> | dl/<deadline>] [t/<tags>]  [r/<recurrence>] [desc/<description>]
+add <task_name> [st/<start> end/<end> | dl/<deadline>] [#<tags>]  [r/<recurrence>] [desc/<description>]
 ```
 
 > Add event or deadline
@@ -77,7 +77,7 @@ add <task_name> [st/<start> end/<end> | dl/<deadline>] [t/<tags>]  [r/<recurrenc
 > Examples:
 
 
-> - `add CS2103T Lecture st/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly t/‘rocks’`
+> - `add CS2103T Lecture st/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
 
 > - `add CS2105 Assignment 1 dl/2016-10-10 10:00`
 
@@ -96,24 +96,24 @@ list [[after/<date>] [before/<date>] [on/<date>][tags=<comma_separated_tags>] [r
 
 
 ```
-tag <task_id> <tag_name> [, <tag_name> …]
+tag <task_id> #<tag_name> [#<tag_name> …]
 ```
 
 > Add tag(s) to a particular entry with a specified id
 
 > Examples:
 
-> - `tag 123 ‘CS2103T’, ‘rocks’`
+> - `tag 123 #CS2103T #rocks`
 
 > Delete tag(s) from a particular entry with a specified id using `untag`
 
-> - `untag 123 ‘rocks’`
+> - `untag 123 #rocks`
 
 > Duplicated tags will only be added once
 
 
 ```
-edit <task_id> [new title] [/st <start> /end <end> | /dl <deadline>] [/t <tags>] [/r <recurrence>] [/desc <description>]
+edit <task_id> [new title] [/st <start> /end <end> | /dl <deadline>] [#<tags>] [/r <recurrence>] [/desc <description>]
 ```
 
 >  Edit the entry with the specified entry id.
@@ -124,7 +124,7 @@ edit <task_id> [new title] [/st <start> /end <end> | /dl <deadline>] [/t <tags>]
 
 > - `edit 3 school`
 
-> - `edit 13 t/yearly`
+> - `edit 13 #yearly`
 
 
 ```
@@ -140,7 +140,7 @@ delete <entry_id>
 
 
 ```
-mark [-d] <entry_id>
+mark <entry_id>
 ```
 
 > Check (or uncheck, for `unmark`) a entry as completed.
@@ -150,6 +150,8 @@ mark [-d] <entry_id>
 > Examples:
 
 > - `mark 42`
+
+> - `unmark 42`
 
 
 ```

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -8,6 +8,7 @@ import seedu.address.model.tag.UniqueTagList;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Adds a task to the address book.
@@ -26,6 +27,8 @@ public class AddCommand extends Command {
     public static final String DEADLINE_FLAG = "dl/";
     public static final String TAG_FLAG = "#";
     public static final String DESC_FLAG = "desc/";
+    public static final String WRONG_DATE_TIME_INPUT = "Wrong date format supplied. The correct format is YYYY-MM-DD HH:mm";
+    public static final Pattern DATE_TIME_FORMAT = Pattern.compile("\\d{4}-\\d{1,2}-\\d{1,2} \\d{2}:\\d{2}");
 
     private final FloatingTask toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,6 +23,9 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New entry added: %1$s";
     public static final String MESSAGE_DUPLICATE_ENTRY = "This entry already exists in the todo list";
+    public static final String DEADLINE_FLAG = "dl/";
+    public static final String TAG_FLAG = "#";
+    public static final String DESC_FLAG = "desc/";
 
     private final FloatingTask toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -26,6 +26,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Edited entry: %1$s";
     public static final String MESSAGE_DUPLICATE_TASK = "This entry already exists in the todo list";
+    public static final String TITLE_FLAG = "title/";
 
     private final int targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -34,19 +34,10 @@ public class ListCommand extends Command {
     private LocalDateTime endDate;
     private LocalDateTime onDate;
     
-    private PredicateBuilder predicateBuilder;
+    private final PredicateBuilder predicateBuilder = new PredicateBuilder();
     
     public ListCommand() {}
-    
-    /**
-     * Convenient constructor
-     * @param keywords
-     */
-    public ListCommand(Set<String> keywords) {
-        this.keywords = keywords;
-        this.predicateBuilder = new PredicateBuilder();
-    }
-    
+
     public void setKeywords(Set<String> keywords) {
         this.keywords = keywords;
     }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,0 +1,217 @@
+package seedu.address.logic.parser;
+
+import java.util.*;
+
+/**
+ * Retrieved from https://github.com/nus-cs2103-AY1617S1/addressbook-level4/ on 2016/10/21
+ * Author: ndt93
+ */
+
+/**
+ * Tokenizes arguments string of the form: {@code preamble <prefix>value <prefix>value ...}<br>
+ *     e.g. {@code some preamble text /t 11.00/dToday /t 12.00 /k /m July}  where prefixes are {@code /t /d /k /m}.<br>
+ * 1. An argument's value can be an empty string e.g. the value of {@code /k} in the above example.<br>
+ * 2. Leading and trailing whitespaces of an argument value will be discarded.<br>
+ * 3. A prefix need not have leading and trailing spaces e.g. the {@code /d in 11.00/dToday} in the above example<br>
+ * 4. An argument may be repeated and all its values will be accumulated e.g. the value of {@code /t}
+ *    in the above example.<br>
+ */
+public class ArgumentTokenizer {
+    /**
+     * A prefix that marks the beginning of an argument.
+     * e.g. '/t' in 'add James /t friend'
+     */
+    public static class Prefix {
+        final String prefix;
+
+        Prefix(String prefix) {
+            this.prefix = prefix;
+        }
+
+        String getPrefix() {
+            return this.prefix;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.prefix == null ? 0 : this.prefix.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Prefix)) {
+                return false;
+            }
+            if (obj == this) {
+                return true;
+            }
+
+            Prefix otherPrefix = (Prefix) obj;
+            return otherPrefix.getPrefix().equals(getPrefix());
+        }
+    }
+
+    /**
+     * Represents a prefix's position in an arguments string
+     */
+    private class PrefixPosition {
+        private int startPosition;
+        private final Prefix prefix;
+
+        PrefixPosition(Prefix prefix, int startPosition) {
+            this.prefix = prefix;
+            this.startPosition = startPosition;
+        }
+
+        int getStartPosition() {
+            return this.startPosition;
+        }
+
+        Prefix getPrefix() {
+            return this.prefix;
+        }
+    }
+
+    /** Given prefixes **/
+    private final List<Prefix> prefixes;
+
+    /** Arguments found after tokenizing **/
+    private final Map<Prefix, List<String>> tokenizedArguments = new HashMap<>();
+
+    /**
+     * Creates an ArgumentTokenizer that can tokenize arguments string as described by prefixes
+     */
+    public ArgumentTokenizer(Prefix... prefixes) {
+        this.prefixes = Arrays.asList(prefixes);
+    }
+
+    /**
+     * @param argsString arguments string of the form: preamble <prefix>value <prefix>value ...
+     */
+    public void tokenize(String argsString) {
+        resetTokenizerState();
+        List<PrefixPosition> positions = findAllPrefixPositions(argsString);
+        extractArguments(argsString, positions);
+    }
+
+    /**
+     * Returns last value of given prefix.
+     */
+    public Optional<String> getValue(Prefix prefix) {
+        return getAllValues(prefix).flatMap((values) -> Optional.of(values.get(values.size() - 1)));
+    }
+
+    /**
+     * Returns all values of given prefix.
+     */
+    public Optional<List<String>> getAllValues(Prefix prefix) {
+        if (!this.tokenizedArguments.containsKey(prefix)) {
+            return Optional.empty();
+        }
+        List<String> values = new ArrayList<>(this.tokenizedArguments.get(prefix));
+        return Optional.of(values);
+    }
+
+    /**
+     * Returns the preamble (text before the first valid prefix), if any. Leading/trailing spaces will be trimmed.
+     *     If the string before the first prefix is empty, Optional.empty() will be returned.
+     */
+    public Optional<String> getPreamble() {
+
+        Optional<String> storedPreamble = getValue(new Prefix(""));
+
+        /* An empty preamble is considered 'no preamble present' */
+        if (storedPreamble.isPresent() && !storedPreamble.get().isEmpty()) {
+            return storedPreamble;
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private void resetTokenizerState() {
+        this.tokenizedArguments.clear();
+    }
+
+    /**
+     * Finds all positions in an arguments string at which any prefix appears
+     */
+    private List<PrefixPosition> findAllPrefixPositions(String argsString) {
+        List<PrefixPosition> positions = new ArrayList<>();
+
+        for (Prefix prefix : this.prefixes) {
+            positions.addAll(findPrefixPositions(argsString, prefix));
+        }
+
+        return positions;
+    }
+
+    /**
+     * Finds all positions in an arguments string at which a given {@code prefix} appears
+     */
+    private List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
+        List<PrefixPosition> positions = new ArrayList<>();
+
+        int argumentStart = argsString.indexOf(prefix.getPrefix());
+        while (argumentStart != -1) {
+            PrefixPosition extendedPrefix = new PrefixPosition(prefix, argumentStart);
+            positions.add(extendedPrefix);
+            argumentStart = argsString.indexOf(prefix.getPrefix(), argumentStart + 1);
+        }
+
+        return positions;
+    }
+
+    /**
+     * Extracts the preamble/arguments and stores them in local variables.
+     * @param prefixPositions must contain all prefixes in the {@code argsString}
+     */
+    private void extractArguments(String argsString, List<PrefixPosition> prefixPositions) {
+
+        // Sort by start position
+        prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
+
+        // Insert a PrefixPosition to represent the preamble
+        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
+        prefixPositions.add(0, preambleMarker);
+
+        // Add a dummy PrefixPosition to represent the end of the string
+        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
+        prefixPositions.add(endPositionMarker);
+
+        // Extract the prefixed arguments and preamble (if any)
+        for (int i = 0; i < prefixPositions.size() - 1; i++) {
+            String argValue = extractArgumentValue(argsString, prefixPositions.get(i), prefixPositions.get(i + 1));
+            saveArgument(prefixPositions.get(i).getPrefix(), argValue);
+        }
+
+    }
+
+    /**
+     * Returns the trimmed value of the argument specified by {@code currentPrefixPosition}.
+     *    The end position of the value is determined by {@code nextPrefixPosition}
+     */
+    private String extractArgumentValue(String argsString,
+                                        PrefixPosition currentPrefixPosition,
+                                        PrefixPosition nextPrefixPosition) {
+        Prefix prefix = currentPrefixPosition.getPrefix();
+
+        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
+        String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
+
+        return value.trim();
+    }
+
+    /**
+     * Stores the value of the given prefix in the state of this tokenizer
+     */
+    private void saveArgument(Prefix prefix, String value) {
+        if (this.tokenizedArguments.containsKey(prefix)) {
+            this.tokenizedArguments.get(prefix).add(value);
+            return;
+        }
+
+        List<String> values = new ArrayList<>();
+        values.add(value);
+        this.tokenizedArguments.put(prefix, values);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -128,6 +128,15 @@ public class ArgumentTokenizer {
         }
     }
 
+    /**
+     * Returns true if the prefix appeared more than once in the arguments
+     */
+    public boolean hasMultiple(Prefix prefix) {
+        Optional<List<String>> allOccurences = getAllValues(prefix);
+
+        return allOccurences.isPresent() && allOccurences.get().size() > 1;
+    }
+
     private void resetTokenizerState() {
         this.tokenizedArguments.clear();
     }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -36,18 +36,7 @@ public class Parser {
     private static final Prefix deadlinePrefix = new Prefix(DEADLINE_FLAG);
     private static final Prefix tagPrefix = new Prefix(TAG_FLAG);
     private static final Prefix descPrefix = new Prefix(DESC_FLAG);
-
-
-    private static final Pattern FLOATING_TASK_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
-            Pattern.compile("(?<title>[^/]+)"
-            		+ "(?<tagArguments>(?: t/[^/]+)?)" // comma separated tags;
-                    + "(?<desc>(?: desc/[^/]*)?)");
-
-    private static final Pattern DEADLINE_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
-            Pattern.compile("(?<title>[^/]+)"
-            		+ "(?<deadlineArguments>(?: dl/\\d{4}-\\d{1,2}-\\d{1,2} \\d{2}:\\d{2}))" // Date time format: DD/MM/YYYY/HH:MM
-            		+ "(?<tagArguments>(?: t/[^/]+)?)" // comma separated tags; 
-            		+ "(?<desc>(?: desc/[^/]*)?)");
+    
     
     private static final Pattern EDIT_TASK_ARGS_FORMAT = Pattern
             .compile("(?<targetIndex>\\d+)\\s*(?<title>[\\s\\w\\d]*)"

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -158,14 +158,8 @@ public class Parser {
      * Extracts the new task's tags from the add command's tag arguments
      * string. Merges duplicate tag strings.
      */
-    private static Set<String> getTagsFromArgs(String tagArguments) throws IllegalValueException {
-        // no tags
-        if (tagArguments.isEmpty()) {
-            return Collections.emptySet();
-        }
-        // replace first delimiter prefix, then split
-        final Collection<String> tagStrings = Arrays.asList(tagArguments.replaceFirst(" t/", "").split(",\\s?"));
-        return new HashSet<>(tagStrings);
+    private static Set<String> getTagsFromArgs(ArgumentTokenizer argsTokenizer) throws IllegalValueException {
+        return unwrapStringCollectionOptional(argsTokenizer.getAllValues(tagPrefix));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -130,22 +130,29 @@ public class Parser {
      */
     private Command prepareAdd(String args) {
     	args = args.trim();
-        final Matcher deadlineMatcher = DEADLINE_DATA_ARGS_FORMAT.matcher(args);
-        final Matcher floatingTaskMatcher = FLOATING_TASK_DATA_ARGS_FORMAT.matcher(args);
+        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(deadlinePrefix, tagPrefix, descPrefix);
+
         // Validate arg string format
-        if (!floatingTaskMatcher.matches() && !deadlineMatcher.matches()) {
+        String title = unwrapStringOptional(argsTokenizer.getPreamble());
+        if (title.isEmpty()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-        if (deadlineMatcher.matches()) {
+
+        if (argsTokenizer.getValue(deadlinePrefix).isPresent()) {
         	try {
-        		return new AddCommand(deadlineMatcher.group("title"), getDeadlineFromArgument(deadlineMatcher.group("deadlineArguments")), getTagsFromArgs(deadlineMatcher.group("tagArguments")), getDescriptionFromArgs(deadlineMatcher.group("desc")));
+        		return new AddCommand(title,
+                    getDeadlineFromArgument(argsTokenizer),
+                    getTagsFromArgs(argsTokenizer),
+                    getDescriptionFromArgs(argsTokenizer));
         	} catch (IllegalValueException ive) {
                 return new IncorrectCommand(ive.getMessage());
             }
-        	
+
         } else {
         	try {
-                return new AddCommand(floatingTaskMatcher.group("title"), getTagsFromArgs(floatingTaskMatcher.group("tagArguments")), getDescriptionFromArgs(floatingTaskMatcher.group("desc")));
+                return new AddCommand(title,
+                    getTagsFromArgs(argsTokenizer),
+                    getDescriptionFromArgs(argsTokenizer));
             } catch (IllegalValueException ive) {
                 return new IncorrectCommand(ive.getMessage());
             }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -12,6 +12,9 @@ import java.util.regex.Pattern;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.AddCommand.DEADLINE_FLAG;
+import static seedu.address.logic.commands.AddCommand.DESC_FLAG;
+import static seedu.address.logic.commands.AddCommand.TAG_FLAG;
 import static seedu.address.logic.commands.ListCommand.AFTER_FLAG;
 import static seedu.address.logic.commands.ListCommand.BEFORE_FLAG;
 import static seedu.address.logic.commands.ListCommand.ON_FLAG;
@@ -28,10 +31,14 @@ public class Parser {
 
     private static final Pattern PERSON_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
 
-    // TODO: Use tokenizer for these
+    // TODO: Use PrettyTime to parse dates
     private static final Prefix startDatePrefix = new Prefix(AFTER_FLAG);
     private static final Prefix endDatePrefix = new Prefix(BEFORE_FLAG);
     private static final Prefix onDatePrefix = new Prefix(ON_FLAG);
+    private static final Prefix deadlinePrefix = new Prefix(DEADLINE_FLAG);
+    private static final Prefix tagPrefix = new Prefix(TAG_FLAG);
+    private static final Prefix descPrefix = new Prefix(DESC_FLAG);
+
 
     private static final Pattern FLOATING_TASK_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
             Pattern.compile("(?<title>[^/]+)"

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -200,12 +200,16 @@ public class Parser {
      * Extracts the new entry's deadline from the add command's tag arguments
      * string. Format: YYYY-MM-DD HH:MM
      */
-    private static LocalDateTime getDeadlineFromArgument(String deadlineArguments) throws IllegalValueException {
-        if (deadlineArguments.isEmpty()) {
-            return LocalDateTime.now();
+    private static LocalDateTime getDeadlineFromArgument(ArgumentTokenizer argsTokenizer) throws IllegalValueException {
+        String deadline = unwrapStringOptional(argsTokenizer.getValue(deadlinePrefix));
+
+        Matcher matcher = DATE_TIME_FORMAT.matcher(deadline);
+        if (!matcher.matches()) {
+            throw new IllegalValueException(WRONG_DATE_TIME_INPUT);
         }
+
         // remove the tag.
-        final List<String> cleanedStrings = Arrays.asList(deadlineArguments.replaceFirst(" dl/", "").split(" "));
+        final List<String> cleanedStrings = Arrays.asList(deadline.split(" "));
         return LocalDateTime.parse(cleanedStrings.get(0) + "T" + cleanedStrings.get(1) + ":00");
     }
     

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -39,20 +39,7 @@ public class Parser {
     private static final Prefix descPrefix = new Prefix(DESC_FLAG);
     private static final Prefix titlePrefix = new Prefix(TITLE_FLAG);
 
-    
-    private static final Pattern EDIT_TASK_ARGS_FORMAT = Pattern
-            .compile("(?<targetIndex>\\d+)\\s*(?<title>[\\s\\w\\d]*)"
-                    + "(?<tagArguments>(?: t/[^/]+)*)"
-                    + "(?<desc>(?: desc/[^/]*)?)");
-
-    private static final Pattern TAG_ARGS_FORMAT = Pattern
-            .compile("(?<targetIndex>\\d+)\\s*(?<tagArguments>(?:[^/]*))");
-    
-    private static final Pattern UNTAG_ARGS_FORMAT = Pattern
-            .compile("(?<targetIndex>\\d+)\\s*(?<tagArguments>(?:[^/]*))");
-
-    public Parser() {
-    }
+    public Parser() {}
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -118,8 +118,8 @@ public class Parser {
      * @return the prepared command
      */
     private Command prepareAdd(String args) {
-    	args = args.trim();
         ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(deadlinePrefix, tagPrefix, descPrefix);
+        argsTokenizer.tokenize(args.trim());
 
         // Validate arg string format
         String title = unwrapStringOptional(argsTokenizer.getPreamble());

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -428,4 +428,20 @@ public class Parser {
         }
     }
 
+    private String unwrapStringOptional(Optional<String> optional) {
+        if (optional.isPresent()) {
+            return optional.get();
+        } else {
+            return "";
+        }
+    }
+
+    private Set<String> unwrapStringCollectionOptional(Optional<List<String>> optional) {
+        if (optional.isPresent()) {
+            return new HashSet(optional.get());
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -12,9 +12,7 @@ import java.util.regex.Pattern;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.AddCommand.DEADLINE_FLAG;
-import static seedu.address.logic.commands.AddCommand.DESC_FLAG;
-import static seedu.address.logic.commands.AddCommand.TAG_FLAG;
+import static seedu.address.logic.commands.AddCommand.*;
 import static seedu.address.logic.commands.ListCommand.AFTER_FLAG;
 import static seedu.address.logic.commands.ListCommand.BEFORE_FLAG;
 import static seedu.address.logic.commands.ListCommand.ON_FLAG;

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -111,7 +111,7 @@ public class Parser {
         argsTokenizer.tokenize(args.trim());
 
         // Validate arg string format
-        String title = unwrapStringOptional(argsTokenizer.getPreamble());
+        String title = unwrapOptionalStringOrEmpty(argsTokenizer.getPreamble());
         if (title.isEmpty()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -142,7 +142,7 @@ public class Parser {
      * string. Merges duplicate tag strings.
      */
     private static Set<String> getTagsFromArgs(ArgumentTokenizer argsTokenizer) throws IllegalValueException {
-        return unwrapStringCollectionOptional(argsTokenizer.getAllValues(tagPrefix));
+        return unwrapOptionalStringCollectionOrEmpty(argsTokenizer.getAllValues(tagPrefix));
     }
 
     /**
@@ -153,7 +153,7 @@ public class Parser {
             throw new IllegalValueException("Command should contain only 1 " + DESC_FLAG + " flag");
         }
 
-        return unwrapStringOptional(argsTokenizer.getValue(descPrefix));
+        return unwrapOptionalStringOrEmpty(argsTokenizer.getValue(descPrefix));
     }
 
     /**
@@ -164,7 +164,7 @@ public class Parser {
             throw new IllegalValueException("Command should contain only 1 " + TITLE_FLAG + "flag");
         }
 
-        return unwrapStringOptional(argsTokenizer.getValue(titlePrefix));
+        return unwrapOptionalStringOrEmpty(argsTokenizer.getValue(titlePrefix));
     }
 
     /**
@@ -179,7 +179,7 @@ public class Parser {
         argsTokenizer.tokenize(args.trim());
 
         // Validate arg string format
-        String idString = unwrapStringOptional(argsTokenizer.getPreamble());
+        String idString = unwrapOptionalStringOrEmpty(argsTokenizer.getPreamble());
         Optional<Integer> index = parseIndex(idString);
         if (!index.isPresent()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
@@ -200,7 +200,7 @@ public class Parser {
      * string. Format: YYYY-MM-DD HH:MM
      */
     private static LocalDateTime getDeadlineFromArgument(ArgumentTokenizer argsTokenizer) throws IllegalValueException {
-        String deadline = unwrapStringOptional(argsTokenizer.getValue(deadlinePrefix));
+        String deadline = unwrapOptionalStringOrEmpty(argsTokenizer.getValue(deadlinePrefix));
 
         Matcher matcher = DATE_TIME_FORMAT.matcher(deadline);
         if (!matcher.matches()) {
@@ -283,7 +283,7 @@ public class Parser {
         argsTokenizer.tokenize(args.trim());
 
         // Validate arg string format
-        String idString = unwrapStringOptional(argsTokenizer.getPreamble());
+        String idString = unwrapOptionalStringOrEmpty(argsTokenizer.getPreamble());
         Optional<Integer> targetIndex = parseIndex(idString);
         if (!targetIndex.isPresent()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
@@ -305,7 +305,7 @@ public class Parser {
         argsTokenizer.tokenize(args.trim());
 
         // Validate arg string format
-        String idString = unwrapStringOptional(argsTokenizer.getPreamble());
+        String idString = unwrapOptionalStringOrEmpty(argsTokenizer.getPreamble());
         Optional<Integer> targetIndex = parseIndex(idString);
         if (!targetIndex.isPresent()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
@@ -383,9 +383,9 @@ public class Parser {
                 listCommand.setKeywords(keywordSet);
             }
 
-            String onDateString = unwrapStringOptional(argsTokenizer.getValue(onDatePrefix));
-            String startDateString = unwrapStringOptional(argsTokenizer.getValue(startDatePrefix));
-            String endDateString = unwrapStringOptional(argsTokenizer.getValue(endDatePrefix));
+            String onDateString = unwrapOptionalStringOrEmpty(argsTokenizer.getValue(onDatePrefix));
+            String startDateString = unwrapOptionalStringOrEmpty(argsTokenizer.getValue(startDatePrefix));
+            String endDateString = unwrapOptionalStringOrEmpty(argsTokenizer.getValue(endDatePrefix));
 
             // Ranged search and specific-day search should be mutually exclusive
             if (!onDateString.isEmpty() && (!startDateString.isEmpty() || !endDateString.isEmpty())) {
@@ -414,7 +414,7 @@ public class Parser {
         }
     }
 
-    private static String unwrapStringOptional(Optional<String> optional) {
+    private static String unwrapOptionalStringOrEmpty(Optional<String> optional) {
         if (optional.isPresent()) {
             return optional.get();
         } else {
@@ -422,9 +422,9 @@ public class Parser {
         }
     }
 
-    private static Set<String> unwrapStringCollectionOptional(Optional<List<String>> optional) {
+    private static Set<String> unwrapOptionalStringCollectionOrEmpty(Optional<List<String>> optional) {
         if (optional.isPresent()) {
-            return new HashSet(optional.get());
+            return new HashSet<String>(optional.get());
         } else {
             return Collections.emptySet();
         }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -216,13 +216,13 @@ public class Parser {
      * Parse LocalDateTime from an input string
      * string. Format: YYYY-MM-DD
      */
-    private static LocalDateTime getLocalDateTimeFromArgument(Optional<String> dateTimeOptional, String time) throws IllegalValueException {
-        if (!dateTimeOptional.isPresent()) {
+    private static LocalDateTime getLocalDateTimeFromArgument(String dateTimeString, String time) throws IllegalValueException {
+        if (dateTimeString.isEmpty()) {
             return null;
         }
         
         // remove the tag.
-        final String cleanedString = dateTimeOptional.get() + "T" + time;
+        final String cleanedString = dateTimeString + "T" + time;
         return LocalDateTime.parse(cleanedString);
     }
     
@@ -383,18 +383,18 @@ public class Parser {
                 listCommand.setKeywords(keywordSet);
             }
 
-            Optional<String> onDateStringOptional = argsTokenizer.getValue(onDatePrefix);
-            Optional<String> startDateStringOptional = argsTokenizer.getValue(startDatePrefix);
-            Optional<String> endDateStringOptional = argsTokenizer.getValue(endDatePrefix);
+            String onDateString = unwrapStringOptional(argsTokenizer.getValue(onDatePrefix));
+            String startDateString = unwrapStringOptional(argsTokenizer.getValue(startDatePrefix));
+            String endDateString = unwrapStringOptional(argsTokenizer.getValue(endDatePrefix));
 
             // Ranged search and specific-day search should be mutually exclusive
-            if (onDateStringOptional.isPresent() && (startDateStringOptional.isPresent() || endDateStringOptional.isPresent())) {
+            if (!onDateString.isEmpty() && (!startDateString.isEmpty() || !endDateString.isEmpty())) {
                 return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_MUTUALLY_EXCLUSIVE_OPTIONS));
             }
             
-            if (!onDateStringOptional.isPresent()) {
-                final LocalDateTime startDate = getLocalDateTimeFromArgument(startDateStringOptional, "00:00:00");
-                final LocalDateTime endDate = getLocalDateTimeFromArgument(endDateStringOptional, "23:59:59");
+            if (onDateString.isEmpty()) {
+                final LocalDateTime startDate = getLocalDateTimeFromArgument(startDateString, "00:00:00");
+                final LocalDateTime endDate = getLocalDateTimeFromArgument(endDateString, "23:59:59");
                 
                 if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
                     return new IncorrectCommand(ListCommand.MESSAGE_INVALID_DATE);
@@ -403,7 +403,7 @@ public class Parser {
                 listCommand.setStartDate(startDate);
                 listCommand.setEndDate(endDate);
             } else {
-                final LocalDateTime onDate = getLocalDateTimeFromArgument(onDateStringOptional, "23:59:59");
+                final LocalDateTime onDate = getLocalDateTimeFromArgument(onDateString, "23:59:59");
                 
                 listCommand.setOnDate(onDate);
             }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -33,9 +33,6 @@ public class Parser {
     private static final Prefix endDatePrefix = new Prefix(BEFORE_FLAG);
     private static final Prefix onDatePrefix = new Prefix(ON_FLAG);
 
-    private static final Pattern LIST_ARGS_FORMAT =
-            Pattern.compile("(?<keywords>\\s*\\S*(?:\\s+\\S+)*)"); // zero or more keywords separated by whitespace
-
     private static final Pattern FLOATING_TASK_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
             Pattern.compile("(?<title>[^/]+)"
             		+ "(?<tagArguments>(?: t/[^/]+)?)" // comma separated tags;

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -171,15 +171,12 @@ public class Parser {
     /**
      * Extracts the description from the add command's description argument
      */
-    private static String getDescriptionFromArgs(String descriptionArguments) throws IllegalValueException {
-        if (descriptionArguments == null || descriptionArguments.isEmpty()) {
-            return "";
-        }
-        String[] descriptionStrings = descriptionArguments.split("/");
-        if (descriptionStrings.length != 2) {
+    private static String getDescriptionFromArgs(ArgumentTokenizer argsTokenizer) throws IllegalValueException {
+        if (argsTokenizer.hasMultiple(descPrefix)) {
             throw new IllegalValueException("Command should contain only 1 'desc/' flag");
         }
-        return descriptionStrings[1];
+
+        return unwrapStringOptional(argsTokenizer.getValue(descPrefix));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -279,22 +279,19 @@ public class Parser {
      * Parses arguments in the context of the tag task command.
      */
     private Command prepareTag(String args) {
-        final Matcher matcher = TAG_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
-        }
-        
-        Optional<Integer> targetIndex = parseIndex(matcher.group("targetIndex"));
+        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(tagPrefix);
+        argsTokenizer.tokenize(args.trim());
+
+        // Validate arg string format
+        String idString = unwrapStringOptional(argsTokenizer.getPreamble());
+        Optional<Integer> targetIndex = parseIndex(idString);
         if (!targetIndex.isPresent()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         }
-        String tagArg = matcher.group("tagArguments");
-        Collection<String> tagStrings = Collections.emptySet();
-        if (!tagArg.isEmpty()) {
-            tagStrings = Arrays.asList(tagArg.split(",\\s?"));
-        }
+
         try {
-            return new TagCommand(targetIndex.get() ,new HashSet<>(tagStrings));
+            Set<String> tagStrings = getTagsFromArgs(argsTokenizer);
+            return new TagCommand(targetIndex.get(), tagStrings);
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());
         }
@@ -304,22 +301,19 @@ public class Parser {
      * Parses arguments in the context of the untag task command.
      */
     private Command prepareUntag(String args) {
-        final Matcher matcher = UNTAG_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
+        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(tagPrefix);
+        argsTokenizer.tokenize(args.trim());
+
+        // Validate arg string format
+        String idString = unwrapStringOptional(argsTokenizer.getPreamble());
+        Optional<Integer> targetIndex = parseIndex(idString);
+        if (!targetIndex.isPresent()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
         }
-        
-        Optional<Integer> targetIndex = parseIndex(matcher.group("targetIndex"));
-        if (!targetIndex.isPresent()) {
-                return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
-        }
-        String tagArg = matcher.group("tagArguments");
-        Collection<String> tagStrings = Collections.emptySet();
-        if (!tagArg.isEmpty()) {
-            tagStrings = Arrays.asList(tagArg.split(",\\s?"));
-        }
+
         try {
-            return new UntagCommand(targetIndex.get() ,new HashSet<>(tagStrings));
+            Set<String> tagStrings = getTagsFromArgs(argsTokenizer);
+            return new UntagCommand(targetIndex.get(), tagStrings);
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());
         }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.AddCommand.*;
+import static seedu.address.logic.commands.EditCommand.TITLE_FLAG;
 import static seedu.address.logic.commands.ListCommand.AFTER_FLAG;
 import static seedu.address.logic.commands.ListCommand.BEFORE_FLAG;
 import static seedu.address.logic.commands.ListCommand.ON_FLAG;
@@ -36,7 +37,8 @@ public class Parser {
     private static final Prefix deadlinePrefix = new Prefix(DEADLINE_FLAG);
     private static final Prefix tagPrefix = new Prefix(TAG_FLAG);
     private static final Prefix descPrefix = new Prefix(DESC_FLAG);
-    
+    private static final Prefix titlePrefix = new Prefix(TITLE_FLAG);
+
     
     private static final Pattern EDIT_TASK_ARGS_FORMAT = Pattern
             .compile("(?<targetIndex>\\d+)\\s*(?<title>[\\s\\w\\d]*)"

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -428,7 +428,7 @@ public class Parser {
         }
     }
 
-    private String unwrapStringOptional(Optional<String> optional) {
+    private static String unwrapStringOptional(Optional<String> optional) {
         if (optional.isPresent()) {
             return optional.get();
         } else {
@@ -436,7 +436,7 @@ public class Parser {
         }
     }
 
-    private Set<String> unwrapStringCollectionOptional(Optional<List<String>> optional) {
+    private static Set<String> unwrapStringCollectionOptional(Optional<List<String>> optional) {
         if (optional.isPresent()) {
             return new HashSet(optional.get());
         } else {

--- a/src/test/java/seedu/address/logic/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/ArgumentTokenizerTest.java
@@ -1,0 +1,147 @@
+package seedu.address.logic.parser;
+
+import org.junit.Test;
+import seedu.address.logic.parser.ArgumentTokenizer.Prefix;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+public class ArgumentTokenizerTest {
+
+    private final Prefix unknownPrefix = new Prefix("--u");
+    private final Prefix slashP = new Prefix("/p");
+    private final Prefix dashT = new Prefix("-t");
+    private final Prefix hatQ = new Prefix("^Q");
+
+    @Test
+    public void accessors_notTokenizedYet() {
+        ArgumentTokenizer tokenizer = new ArgumentTokenizer(slashP);
+        assertPreambleAbsent(tokenizer);
+        assertArgumentAbsent(tokenizer, slashP);
+    }
+
+    @Test
+    public void tokenize_emptyArgsString_noValues() {
+        ArgumentTokenizer tokenizer = new ArgumentTokenizer(slashP);
+        String argsString = "  ";
+        tokenizer.tokenize(argsString);
+
+        assertPreambleAbsent(tokenizer);
+        assertArgumentAbsent(tokenizer, slashP);
+    }
+
+    private void assertPreamblePresent(ArgumentTokenizer argsTokenizer, String expectedPreamble) {
+        assertEquals(expectedPreamble, argsTokenizer.getPreamble().get());
+    }
+
+    private void assertPreambleAbsent(ArgumentTokenizer argsTokenizer) {
+        assertFalse(argsTokenizer.getPreamble().isPresent());
+    }
+
+    private void assertArgumentPresent(ArgumentTokenizer argsTokenizer, Prefix prefix, String... expectedValues) {
+
+        // Verify the last value is returned
+        assertEquals(expectedValues[expectedValues.length - 1], argsTokenizer.getValue(prefix).get());
+
+        // Verify the number of values returned is as expected
+        assertEquals(expectedValues.length, argsTokenizer.getAllValues(prefix).get().size());
+
+        // Verify all values returned are as expected and in order
+        for (int i = 0; i < expectedValues.length; i++) {
+            assertEquals(expectedValues[i], argsTokenizer.getAllValues(prefix).get().get(i));
+        }
+    }
+
+    private void assertArgumentAbsent(ArgumentTokenizer argsTokenizer, Prefix prefix) {
+        assertFalse(argsTokenizer.getValue(prefix).isPresent());
+    }
+
+    @Test
+    public void tokenize_noPrefixes_allTakenAsPreamble() {
+        ArgumentTokenizer tokenizer = new ArgumentTokenizer();
+        String argsString = "  some random string /t tag with leading and trailing spaces ";
+        tokenizer.tokenize(argsString);
+
+        // Same string expected as preamble, but leading/trailing spaces should be trimmed
+        assertPreamblePresent(tokenizer, argsString.trim());
+
+    }
+
+    @Test
+    public void tokenize_oneArgument() {
+        ArgumentTokenizer tokenizer = new ArgumentTokenizer(slashP);
+
+        // Preamble present
+        tokenizer.tokenize("  Some preamble string /p Argument value ");
+        assertPreamblePresent(tokenizer, "Some preamble string");
+        assertArgumentPresent(tokenizer, slashP, "Argument value");
+
+        // No preamble
+        tokenizer.tokenize(" /p   Argument value ");
+        assertPreambleAbsent(tokenizer);
+        assertArgumentPresent(tokenizer, slashP, "Argument value");
+
+    }
+
+    @Test
+    public void tokenize_multipleArguments() {
+        ArgumentTokenizer tokenizer = new ArgumentTokenizer(slashP, dashT, hatQ);
+
+        // Only two arguments are present
+        tokenizer.tokenize("SomePreambleString -t dashT-Value/pslashP value");
+        assertPreamblePresent(tokenizer, "SomePreambleString");
+        assertArgumentPresent(tokenizer, slashP, "slashP value");
+        assertArgumentPresent(tokenizer, dashT, "dashT-Value");
+        assertArgumentAbsent(tokenizer, hatQ);
+
+        /* Also covers: Cases where the prefix doesn't have a space before/after it */
+
+        // All three arguments are present, no spaces before the prefixes
+        tokenizer.tokenize("Different Preamble String^Q 111-t dashT-Value/p slashP value");
+        assertPreamblePresent(tokenizer, "Different Preamble String");
+        assertArgumentPresent(tokenizer, slashP, "slashP value");
+        assertArgumentPresent(tokenizer, dashT, "dashT-Value");
+        assertArgumentPresent(tokenizer, hatQ, "111");
+
+        /* Also covers: Reusing of the tokenizer multiple times */
+
+        // Reuse tokenizer on an empty string to ensure state is correctly reset
+        //   (i.e. no stale values from the previous tokenizing remain in the state)
+        tokenizer.tokenize("");
+        assertPreambleAbsent(tokenizer);
+        assertArgumentAbsent(tokenizer, slashP);
+
+        /** Also covers: testing for prefixes not specified as a prefix **/
+
+        // Prefixes not previously given to the tokenizer should not return any values
+        String stringWithUnknownPrefix = unknownPrefix.getPrefix() + "some value";
+        tokenizer.tokenize(stringWithUnknownPrefix);
+        assertArgumentAbsent(tokenizer, unknownPrefix);
+        assertPreamblePresent(tokenizer, stringWithUnknownPrefix); // Unknown prefix is taken as part of preamble
+    }
+
+    @Test
+    public void tokenize_multipleArgumentsWithRepeats() {
+        ArgumentTokenizer tokenizer = new ArgumentTokenizer(slashP, dashT, hatQ);
+
+        // Two arguments repeated, some have empty values
+        tokenizer.tokenize("SomePreambleString -t dashT-Value ^Q ^Q-t another dashT value /p slashP value -t");
+        assertPreamblePresent(tokenizer, "SomePreambleString");
+        assertArgumentPresent(tokenizer, slashP, "slashP value");
+        assertArgumentPresent(tokenizer, dashT, "dashT-Value", "another dashT value", "");
+        assertArgumentPresent(tokenizer, hatQ, "", "");
+    }
+
+    @Test
+    public void equalsMethod() {
+        Prefix aaa = new Prefix("aaa");
+
+        assertEquals(aaa, aaa);
+        assertEquals(aaa, new Prefix("aaa"));
+
+        assertNotEquals(aaa, "aaa");
+        assertNotEquals(aaa, new Prefix("aab"));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -29,6 +29,8 @@ import java.util.StringJoiner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.*;
+import static seedu.address.logic.commands.AddCommand.TAG_FLAG;
+import static seedu.address.logic.commands.EditCommand.TITLE_FLAG;
 
 public class LogicManagerTest {
 
@@ -149,7 +151,7 @@ public class LogicManagerTest {
     public void execute_add_invalidArgsFormat() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
         assertCommandBehavior(
-                "add t/NTUC Valid Task", expectedMessage);
+                "add " + TAG_FLAG + "NTUC Valid Task", expectedMessage);
     }
 
     @Test
@@ -157,7 +159,7 @@ public class LogicManagerTest {
         assertCommandBehavior(
                 "add []\\[;]", Title.MESSAGE_NAME_CONSTRAINTS);
         assertCommandBehavior(
-                "add Valid Task t/invalid_-[.tag", Tag.MESSAGE_TAG_CONSTRAINTS);
+                "add Valid Task " + TAG_FLAG + "invalid_-[.tag", Tag.MESSAGE_TAG_CONSTRAINTS);
     }
 
     @Test
@@ -441,7 +443,7 @@ public class LogicManagerTest {
         List<FloatingTask> expectedList = helper.generateEntryList(t1);
         AddressBook expectedAB = helper.generateAddressBook(expectedList);
         
-        assertCommandBehavior("tag 1 **", expectedMessage, expectedAB, expectedList);
+        assertCommandBehavior("tag 1 " + TAG_FLAG + "**", expectedMessage, expectedAB, expectedList);
     }
 
     @Test
@@ -518,7 +520,7 @@ public class LogicManagerTest {
         List<FloatingTask> expectedList = helper.generateEntryList(t1);
         AddressBook expectedAB = helper.generateAddressBook(expectedList);
         
-        assertCommandBehavior("untag 1 **", expectedMessage, expectedAB, expectedList);
+        assertCommandBehavior("untag 1 " + TAG_FLAG + "**", expectedMessage, expectedAB, expectedList);
     }
 
     @Test
@@ -617,11 +619,9 @@ public class LogicManagerTest {
             UniqueTagList tags = p.getTags();
 
             if (!tags.isEmpty()){
-                StringJoiner joiner = new StringJoiner(",");
                 for (Tag t : tags) {
-                    joiner.add(t.tagName);
+                    cmd.append(" " + TAG_FLAG).append(t.tagName);
                 }
-                cmd.append(" t/").append(joiner.toString());
             }
 
             return cmd.toString();
@@ -631,15 +631,13 @@ public class LogicManagerTest {
             StringBuffer cmd = new StringBuffer();
             
             cmd.append(String.format("edit %d ", index));
-            cmd.append(title);
+            cmd.append(TITLE_FLAG).append(title);
 
             UniqueTagList tags = p.getTags();
             if (!tags.isEmpty()){
-                StringJoiner joiner = new StringJoiner(",");
                 for (Tag t : tags) {
-                    joiner.add(t.tagName);
+                    cmd.append(" " + TAG_FLAG).append(t.tagName);
                 }
-                cmd.append(" t/").append(joiner.toString());
             }
             return cmd.toString();
         }
@@ -649,15 +647,12 @@ public class LogicManagerTest {
             StringBuffer cmd = new StringBuffer();
             
             cmd.append(String.format("tag %d ", index));
-            
-            StringJoiner joiner = new StringJoiner(",");
+
             for (Tag t : tags) {
-                joiner.add(t.tagName);
+                cmd.append(" " + TAG_FLAG).append(t.tagName);
             }
             
-            cmd.append(joiner.toString());
-            
-            return cmd.toString().replaceAll(",$", "");
+            return cmd.toString();
         }
         
         /** Generates the tag command based on the given tag and index*/
@@ -672,14 +667,11 @@ public class LogicManagerTest {
             
             cmd.append(String.format("untag %d ", index));
             
-            StringJoiner joiner = new StringJoiner(",");
             for (Tag t : tags) {
-                joiner.add(t.tagName);
+                cmd.append(" " + TAG_FLAG).append(t.tagName);
             }
             
-            cmd.append(joiner.toString());
-            
-            return cmd.toString().replaceAll(",$", "");
+            return cmd.toString();
         }
 
         /** Generates the untag command based on the given tag and index*/

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import org.junit.Test;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ArgumentTokenizer.Prefix;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/seedu/address/testutil/TestEntry.java
+++ b/src/test/java/seedu/address/testutil/TestEntry.java
@@ -11,6 +11,8 @@ import seedu.address.model.task.*;
 
 import java.util.StringJoiner;
 
+import static seedu.address.logic.commands.AddCommand.TAG_FLAG;
+
 /**
  * A mutable task object. For testing only.
  */
@@ -84,7 +86,7 @@ public class TestEntry implements Entry {
         StringBuilder sb = new StringBuilder();
         sb.append("add " + this.getTitle().fullTitle + " ");
         if (!this.getTags().isEmpty()) {
-            sb.append("t/");
+            sb.append(TAG_FLAG);
         }
         StringJoiner sj = new StringJoiner(",");
         this.getTags().getInternalList().stream().forEach(s -> sj.add(s.tagName));

--- a/src/test/java/seedu/address/testutil/TestEntry.java
+++ b/src/test/java/seedu/address/testutil/TestEntry.java
@@ -86,11 +86,8 @@ public class TestEntry implements Entry {
         StringBuilder sb = new StringBuilder();
         sb.append("add " + this.getTitle().fullTitle + " ");
         if (!this.getTags().isEmpty()) {
-            sb.append(TAG_FLAG);
+            this.getTags().getInternalList().forEach(s -> sb.append(" " + TAG_FLAG).append(s.tagName));
         }
-        StringJoiner sj = new StringJoiner(",");
-        this.getTags().getInternalList().stream().forEach(s -> sj.add(s.tagName));
-        sb.append(sj.toString());
         return sb.toString();
     }
 


### PR DESCRIPTION
Implements #50 
Implements #39 

Major changes:
- Parser.java: Change the way commands are parsed
- Changed tags to use separate `#` instead of `t/x, y, z` in add/edit commands
- Edit command: add a `title/`flag
- Tag command: changed from comma-separated to using `#`

Tests are passing
