### PR TITLE
115 hide completed tasks

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -45,132 +45,133 @@ delete 1
 
 | Command |Format |
 | --- | --- |
-|add|`add <task_name> [start/<start> end/<end>] [#<tag_name> ...]  [r/<recurrence>] [desc/<description>]`|
-|list|`list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]`|
-|tag|`tag <task_id> #<tag_name> [#<tag_name> ...]`|
-|untag|`untag <task_id> #<tag_name> [#<tag_name> ...]`|
-|edit|`edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]`|
+|add|`add <task_name[start/<startend/<end>] [#<tag_name...]  [r/<recurrence>] [desc/<description>]`|
+|list|`list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name...] [recurrence=<recurrence_value>] [desc=<description_value>]]`|
+|tag|`tag <task_id#<tag_name[#<tag_name...]`|
+|untag|`untag <task_id#<tag_name[#<tag_name...]`|
+|edit|`edit <task_id[title/new title] [start/<startend/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]`|
 |delete|`delete <task_id>`|
 |mark|`mark <task_id>`|
 |unmark|`unmark <task_id>`|
 |show|`show <task_id>`|
 |help|`help [<command>]`|
-|option|`option [<type>/<value> ...]`|
+|option|`option [<type>/<value...]`|
 
 ## Commands
 
 #### Adding
 ```
-add <task_name> [start/<start> end/<end>] [#<tag_name> ...]  [r/<recurrence>] [desc/<description>]
+add <task_name[start/<startend/<end>] [#<tag_name...]  [r/<recurrence>] [desc/<description>]
 ```
 
-> Add event or deadline
+Add event or deadline
 
-> Examples:
+Examples:
 
+- `add CS2103T Lecture start/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
 
-> - `add CS2103T Lecture start/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
-
-> - `add CS2105 Assignment 1 end/2016-10-10 10:00`
+- `add CS2105 Assignment 1 end/2016-10-10 10:00`
 
 #### Listing
 ```
-list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]] [#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]
+list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]] [#<tag_name...] [recurrence=<recurrence_value>] [desc=<description_value>]]
 ```
 
-> List all or filtered entries
+List all entries, or entries that satisfy the given search criteria. For the best user experience, completed entries are _automatically excluded_.
 
-> Examples:
+Examples:
 
-> - `list`
+- `list`
 
-> - `list after/2016-10-10`
+- `list after/2016-10-10`
 
-> - `list buy banana #groceries`
+- `list buy banana #groceries`
+
+If you want to include completed entries in your search, replace `list` with `list-completed`
 
 #### Tagging
 ```
-tag <task_id> #<tag_name> [#<tag_name>...]
+tag <task_id#<tag_name[#<tag_name>...]
 ```
 
-> Add tag(s) to a particular entry with a specified id
+Add tag(s) to a particular entry with a specified id
 
-> Examples:
+Examples:
 
-> - `tag 123 #CS2103T #rocks`
+- `tag 123 #CS2103T #rocks`
 
-> Delete tag(s) from a particular entry with a specified id using `untag`
+Delete tag(s) from a particular entry with a specified id using `untag`
 
-> - `untag 123 #rocks`
+- `untag 123 #rocks`
 
-> Duplicated tags will only be added once
+Duplicated tags will only be added once
 
 #### Editing
 ```
-edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]
+edit <task_id[title/new title] [start/<startend/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]
 ```
 
->  Edit the entry with the specified entry id.
+ Edit the entry with the specified entry id.
 
->  `list` should be executed before this command to obtain a entry id.
+ `list` should be executed before this command to obtain a entry id.
 
-> Examples:
+Examples:
 
-> - `edit 3 school`
+- `edit 3 school`
 
-> - `edit 13 #yearly`
+- `edit 13 #yearly`
 
 
 #### Deleting
 ```
 delete <entry_id>
 ```
-> Delete the task with a particular entry id
+Delete the task with a particular entry id
 
-> `list` should be executed before this command to obtain a entry id.
+`list` should be executed before this command to obtain a entry id.
 
-> Examples:
+Examples:
 
-> - `Delete 42`
+- `Delete 42`
 
 #### Marking
 ```
 mark <entry_id>
 ```
 
-> Check (or uncheck, for `unmark`) a entry as completed.
+Check (or uncheck, for `unmark`) a entry as completed.
 
-> `list` should be executed before this command to obtain a entry id.
+`list` should be executed before this command to obtain a entry id.
 
-> Examples:
+Examples:
 
-> - `mark 42`
+- `mark 42`
 
-> - `unmark 42`
+- `unmark 42`
 
 #### Showing
 ```
 show <entry_id>
 ```
-> Display the details of a particular entry
+Display the details of a particular entry
 
-> `list` should be executed before this command to obtain a entry id.
+`list` should be executed before this command to obtain a entry id.
 
 #### Help
 ```
 help [<command>]
 ```
 
-> Show available commands and how to use them
+Show available commands and how to use them
 
-> Help is also shown if you enter an incorrect command e.g. abcd
+Help is also shown if you enter an incorrect command e.g. abcd
 
 #### option
 ```
-option [<type>/<value> ...]
+option [<type>/<value...]
 ```
-> Configure user settings: name, file path to data file
+Configure user settings: name, file path to data file
 
-> Examples:
+Examples:
 
-> - `config save/data/MyNewLocation.xml`
+- `config save/data/MyNewLocation.xml`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -45,133 +45,132 @@ delete 1
 
 | Command |Format |
 | --- | --- |
-|add|`add <task_name[start/<startend/<end>] [#<tag_name...]  [r/<recurrence>] [desc/<description>]`|
-|list|`list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name...] [recurrence=<recurrence_value>] [desc=<description_value>]]`|
-|tag|`tag <task_id#<tag_name[#<tag_name...]`|
-|untag|`untag <task_id#<tag_name[#<tag_name...]`|
-|edit|`edit <task_id[title/new title] [start/<startend/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]`|
+|add|`add <task_name> [start/<start> end/<end>] [#<tag_name> ...]  [r/<recurrence>] [desc/<description>]`|
+|list|`list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]`|
+|tag|`tag <task_id> #<tag_name> [#<tag_name> ...]`|
+|untag|`untag <task_id> #<tag_name> [#<tag_name> ...]`|
+|edit|`edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]`|
 |delete|`delete <task_id>`|
 |mark|`mark <task_id>`|
 |unmark|`unmark <task_id>`|
 |show|`show <task_id>`|
 |help|`help [<command>]`|
-|option|`option [<type>/<value...]`|
+|option|`option [<type>/<value> ...]`|
 
 ## Commands
 
 #### Adding
 ```
-add <task_name[start/<startend/<end>] [#<tag_name...]  [r/<recurrence>] [desc/<description>]
+add <task_name> [start/<start> end/<end>] [#<tag_name> ...]  [r/<recurrence>] [desc/<description>]
 ```
 
-Add event or deadline
+> Add event or deadline
 
-Examples:
+> Examples:
 
-- `add CS2103T Lecture start/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
 
-- `add CS2105 Assignment 1 end/2016-10-10 10:00`
+> - `add CS2103T Lecture start/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
+
+> - `add CS2105 Assignment 1 end/2016-10-10 10:00`
 
 #### Listing
 ```
-list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]] [#<tag_name...] [recurrence=<recurrence_value>] [desc=<description_value>]]
+list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]] [#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]
 ```
 
-List all entries, or entries that satisfy the given search criteria. For the best user experience, completed entries are _automatically excluded_.
+> List all or filtered entries
 
-Examples:
+> Examples:
 
-- `list`
+> - `list`
 
-- `list after/2016-10-10`
+> - `list after/2016-10-10`
 
-- `list buy banana #groceries`
-
-If you want to include completed entries in your search, replace `list` with `list-completed`
+> - `list buy banana #groceries`
 
 #### Tagging
 ```
-tag <task_id#<tag_name[#<tag_name>...]
+tag <task_id> #<tag_name> [#<tag_name>...]
 ```
 
-Add tag(s) to a particular entry with a specified id
+> Add tag(s) to a particular entry with a specified id
 
-Examples:
+> Examples:
 
-- `tag 123 #CS2103T #rocks`
+> - `tag 123 #CS2103T #rocks`
 
-Delete tag(s) from a particular entry with a specified id using `untag`
+> Delete tag(s) from a particular entry with a specified id using `untag`
 
-- `untag 123 #rocks`
+> - `untag 123 #rocks`
 
-Duplicated tags will only be added once
+> Duplicated tags will only be added once
 
 #### Editing
 ```
-edit <task_id[title/new title] [start/<startend/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]
+edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]
 ```
 
- Edit the entry with the specified entry id.
+>  Edit the entry with the specified entry id.
 
- `list` should be executed before this command to obtain a entry id.
+>  `list` should be executed before this command to obtain a entry id.
 
-Examples:
+> Examples:
 
-- `edit 3 school`
+> - `edit 3 school`
 
-- `edit 13 #yearly`
+> - `edit 13 #yearly`
 
 
 #### Deleting
 ```
 delete <entry_id>
 ```
-Delete the task with a particular entry id
+> Delete the task with a particular entry id
 
-`list` should be executed before this command to obtain a entry id.
+> `list` should be executed before this command to obtain a entry id.
 
-Examples:
+> Examples:
 
-- `Delete 42`
+> - `Delete 42`
 
 #### Marking
 ```
 mark <entry_id>
 ```
 
-Check (or uncheck, for `unmark`) a entry as completed.
+> Check (or uncheck, for `unmark`) a entry as completed.
 
-`list` should be executed before this command to obtain a entry id.
+> `list` should be executed before this command to obtain a entry id.
 
-Examples:
+> Examples:
 
-- `mark 42`
+> - `mark 42`
 
-- `unmark 42`
+> - `unmark 42`
 
 #### Showing
 ```
 show <entry_id>
 ```
-Display the details of a particular entry
+> Display the details of a particular entry
 
-`list` should be executed before this command to obtain a entry id.
+> `list` should be executed before this command to obtain a entry id.
 
 #### Help
 ```
 help [<command>]
 ```
 
-Show available commands and how to use them
+> Show available commands and how to use them
 
-Help is also shown if you enter an incorrect command e.g. abcd
+> Help is also shown if you enter an incorrect command e.g. abcd
 
 #### option
 ```
-option [<type>/<value...]
+option [<type>/<value> ...]
 ```
-Configure user settings: name, file path to data file
+> Configure user settings: name, file path to data file
 
-Examples:
+> Examples:
 
-- `config save/data/MyNewLocation.xml`
+> - `config save/data/MyNewLocation.xml`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -87,9 +87,9 @@ Examples:
 
 - `list buy banana #groceries`
 
-If you want to include completed entries in your search, replace `list` with `list-completed`
+If you want to include completed entries in your search, replace `list` with `list-all`
 
-- `list-completed buy banana`
+- `list-all buy banana`
 
 #### Tagging
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -53,7 +53,6 @@ delete 1
 |delete|`delete <task_id>`|
 |mark|`mark <task_id>`|
 |unmark|`unmark <task_id>`|
-|show|`show <task_id>`|
 |help|`help [<command>]`|
 |option|`option [<type>/<value> ...]`|
 
@@ -64,113 +63,109 @@ delete 1
 add <task_name> [start/<start> end/<end>] [#<tag_name> ...]  [r/<recurrence>] [desc/<description>]
 ```
 
-> Add event or deadline
+Add event or deadline
 
-> Examples:
+Examples:
 
 
-> - `add CS2103T Lecture start/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
+- `add CS2103T Lecture start/2016-10-10 10:00 end/2016-10-10 12:00 r/weekly #rocks`
 
-> - `add CS2105 Assignment 1 end/2016-10-10 10:00`
+- `add CS2105 Assignment 1 end/2016-10-10 10:00`
 
 #### Listing
 ```
 list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]] [#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]
 ```
 
-> List all or filtered entries
+List all entries, or entries that satisfy the given search criteria. For the best user experience, completed entries are _automatically excluded_.
 
-> Examples:
+Examples:
 
-> - `list`
+- `list`
 
-> - `list after/2016-10-10`
+- `list after/2016-10-10`
 
-> - `list buy banana #groceries`
+- `list buy banana #groceries`
+
+If you want to include completed entries in your search, replace `list` with `list-completed`
+
+- `list-completed buy banana`
 
 #### Tagging
 ```
 tag <task_id> #<tag_name> [#<tag_name>...]
 ```
 
-> Add tag(s) to a particular entry with a specified id
+Add tag(s) to a particular entry with a specified id
 
-> Examples:
+Examples:
 
-> - `tag 123 #CS2103T #rocks`
+- `tag 123 #CS2103T #rocks`
 
-> Delete tag(s) from a particular entry with a specified id using `untag`
+Delete tag(s) from a particular entry with a specified id using `untag`
 
-> - `untag 123 #rocks`
+- `untag 123 #rocks`
 
-> Duplicated tags will only be added once
+Duplicated tags will only be added once
 
 #### Editing
 ```
 edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]
 ```
 
->  Edit the entry with the specified entry id.
+ Edit the entry with the specified entry id.
 
->  `list` should be executed before this command to obtain a entry id.
+ `list` should be executed before this command to obtain a entry id.
 
-> Examples:
+Examples:
 
-> - `edit 3 school`
+- `edit 3 school`
 
-> - `edit 13 #yearly`
+- `edit 13 #yearly`
 
 
 #### Deleting
 ```
 delete <entry_id>
 ```
-> Delete the task with a particular entry id
+Delete the task with a particular entry id
 
-> `list` should be executed before this command to obtain a entry id.
+`list` should be executed before this command to obtain a entry id.
 
-> Examples:
+Examples:
 
-> - `Delete 42`
+- `Delete 42`
 
 #### Marking
 ```
 mark <entry_id>
 ```
 
-> Check (or uncheck, for `unmark`) a entry as completed.
+Check (or uncheck, for `unmark`) a entry as completed.
 
-> `list` should be executed before this command to obtain a entry id.
+`list` should be executed before this command to obtain a entry id.
 
-> Examples:
+Examples:
 
-> - `mark 42`
+- `mark 42`
 
-> - `unmark 42`
-
-#### Showing
-```
-show <entry_id>
-```
-> Display the details of a particular entry
-
-> `list` should be executed before this command to obtain a entry id.
+- `unmark 42`
 
 #### Help
 ```
 help [<command>]
 ```
 
-> Show available commands and how to use them
+Show available commands and how to use them
 
-> Help is also shown if you enter an incorrect command e.g. abcd
+Help is also shown if you enter an incorrect command e.g. abcd
 
 #### option
 ```
 option [<type>/<value> ...]
 ```
-> Configure user settings: name, file path to data file
+Configure user settings: name, file path to data file
 
-> Examples:
+Examples:
 
-> - `config save/data/MyNewLocation.xml`
+- `config save/data/MyNewLocation.xml`

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -29,16 +29,18 @@ public class ListCommand extends Command {
     public static final String AFTER_FLAG = "after/";
     public static final String BEFORE_FLAG = "before/";
     public static final String ON_FLAG = "on/";
+    public static final String COMPLETED_FLAG = "completed/";
 
     private Set<String> keywords;
     private Set<String> tags;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private LocalDateTime onDate;
+    private final boolean includeCompleted;
     
     private final PredicateBuilder predicateBuilder = new PredicateBuilder();
     
-    public ListCommand() {}
+    public ListCommand(boolean includeCompleted) { this.includeCompleted = includeCompleted; }
 
     public void setKeywords(Set<String> keywords) {
         this.keywords = keywords;
@@ -65,9 +67,9 @@ public class ListCommand extends Command {
         if (isListAll()) {
             return showAll();
         } else {
-            Predicate<Entry> predicate = predicateBuilder.buildPredicate(keywords, tags, startDate, endDate, onDate);
+            Predicate<Entry> predicate = predicateBuilder.buildPredicate(keywords, tags, startDate, endDate, onDate, includeCompleted);
             model.updateFilteredEntryListPredicate(predicate);
-            
+
             return new CommandResult(getMessageForPersonListShownSummary(model.getFilteredPersonList().size()));
         }
     }
@@ -86,6 +88,7 @@ public class ListCommand extends Command {
                 && (tags == null || tags.isEmpty())
                 && startDate == null
                 && endDate == null
-                && onDate == null;
+                && onDate == null
+                && includeCompleted;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -15,6 +15,8 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String LIST_COMPLETED_COMMAND_WORD = "list-completed";
+
     public static final String MESSAGE_SUCCESS = "Listed all entries";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": List all entries whose titles contain any of "
@@ -29,7 +31,6 @@ public class ListCommand extends Command {
     public static final String AFTER_FLAG = "after/";
     public static final String BEFORE_FLAG = "before/";
     public static final String ON_FLAG = "on/";
-    public static final String COMPLETED_FLAG = "completed/";
 
     private Set<String> keywords;
     private Set<String> tags;

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -15,7 +15,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String LIST_COMPLETED_COMMAND_WORD = "list-completed";
+    public static final String LIST_ALL_COMMAND_WORD = "list-all";
 
     public static final String MESSAGE_SUCCESS = "Listed all entries";
 

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -17,11 +17,9 @@ import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.AddCommand.*;
+import static seedu.address.logic.commands.ListCommand.*;
 import static seedu.address.logic.commands.OptionCommand.SAVE_LOCATION_FLAG;
 import static seedu.address.logic.commands.EditCommand.TITLE_FLAG;
-import static seedu.address.logic.commands.ListCommand.AFTER_FLAG;
-import static seedu.address.logic.commands.ListCommand.BEFORE_FLAG;
-import static seedu.address.logic.commands.ListCommand.ON_FLAG;
 
 /**
  * Parses user input.
@@ -47,6 +45,7 @@ public class Parser {
     private static final Prefix tagPrefix = new Prefix(TAG_FLAG);
     private static final Prefix descPrefix = new Prefix(DESC_FLAG);
     private static final Prefix titlePrefix = new Prefix(TITLE_FLAG);
+    private static final Prefix completedPrefix = new Prefix(COMPLETED_FLAG);
     private static final PrettyTimeParser prettyTimeParser = new PrettyTimeParser();
     private static final DateFormat dateTimeFormat = new SimpleDateFormat(DATE_TIME_FORMAT);
     private static final DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
@@ -430,14 +429,15 @@ public class Parser {
     private Command prepareList(String args) {
         // Guard statement
         if (args.isEmpty()) {
-            return new ListCommand();
+            return new ListCommand(false);
         }
 
-        final ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(startDatePrefix, endDatePrefix, onDatePrefix, tagPrefix);
+        final ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(startDatePrefix, endDatePrefix, onDatePrefix, tagPrefix, completedPrefix);
         argsTokenizer.tokenize(args);
 
         try {
-            ListCommand listCommand = new ListCommand();
+            boolean includeCompleted = argsTokenizer.getValue(completedPrefix).isPresent();
+            ListCommand listCommand = new ListCommand(includeCompleted);
 
             // keywords delimited by whitespace
             Optional<String> keywordsString = argsTokenizer.getPreamble();

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -45,7 +45,6 @@ public class Parser {
     private static final Prefix tagPrefix = new Prefix(TAG_FLAG);
     private static final Prefix descPrefix = new Prefix(DESC_FLAG);
     private static final Prefix titlePrefix = new Prefix(TITLE_FLAG);
-    private static final Prefix completedPrefix = new Prefix(COMPLETED_FLAG);
     private static final PrettyTimeParser prettyTimeParser = new PrettyTimeParser();
     private static final DateFormat dateTimeFormat = new SimpleDateFormat(DATE_TIME_FORMAT);
     private static final DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
@@ -95,7 +94,10 @@ public class Parser {
             return prepareUntag(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return prepareList(arguments);
+            return prepareList(arguments, false);
+
+        case ListCommand.LIST_COMPLETED_COMMAND_WORD:
+            return prepareList(arguments, true);
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
@@ -426,17 +428,16 @@ public class Parser {
      *            full command args string
      * @return the prepared command
      */
-    private Command prepareList(String args) {
+    private Command prepareList(String args, boolean includeCompleted) {
         // Guard statement
         if (args.isEmpty()) {
-            return new ListCommand(false);
+            return new ListCommand(includeCompleted);
         }
 
-        final ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(startDatePrefix, endDatePrefix, onDatePrefix, tagPrefix, completedPrefix);
+        final ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(startDatePrefix, endDatePrefix, onDatePrefix, tagPrefix);
         argsTokenizer.tokenize(args);
 
         try {
-            boolean includeCompleted = argsTokenizer.getValue(completedPrefix).isPresent();
             ListCommand listCommand = new ListCommand(includeCompleted);
 
             // keywords delimited by whitespace

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -96,7 +96,7 @@ public class Parser {
         case ListCommand.COMMAND_WORD:
             return prepareList(arguments, false);
 
-        case LIST_COMPLETED_COMMAND_WORD:
+        case LIST_ALL_COMMAND_WORD:
             return prepareList(arguments, true);
 
         case UndoCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -41,8 +41,11 @@ public interface Model {
     /** Returns the filtered task list as an {@code UnmodifiableObservableList<ReadOnlyPerson>} */
     UnmodifiableObservableList<Entry> getFilteredPersonList();
 
-    /** Updates the filter of the filtered task list to show all persons */
+    /** Updates the filter of the filtered task list to show all entries */
     void updateFilteredListToShowAll();
+
+    /** Updates the filter of the filtered task list to show all entries excluding completed ones */
+    void updateFilteredListToShowAllWithoutCompleted();
 
     /** Updates the filter of the filtered task list*/
     void updateFilteredEntryListPredicate(Predicate<Entry> predicate);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -42,6 +42,7 @@ public class ModelManager extends ComponentManager implements Model {
 
         taskManager = new TaskManager(src);
         filteredPersons = new FilteredList<>(taskManager.getEntries());
+        updateFilteredListToShowAllWithoutCompleted();
     }
 
     public ModelManager() {
@@ -51,6 +52,7 @@ public class ModelManager extends ComponentManager implements Model {
     public ModelManager(ReadOnlyTaskManager initialData, UserPrefs userPrefs) {
         taskManager = new TaskManager(initialData);
         filteredPersons = new FilteredList<>(taskManager.getEntries());
+        updateFilteredListToShowAllWithoutCompleted();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -77,7 +77,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public synchronized void addTask(Entry entry) throws UniqueTaskList.DuplicateTaskException {
         taskManager.addTask(entry);
-        updateFilteredListToShowAll();
+        updateFilteredListToShowAllWithoutCompleted();
         indicateAddressBookChanged();
     }
 
@@ -85,35 +85,35 @@ public class ModelManager extends ComponentManager implements Model {
     public synchronized void editTask(Update update)
             throws EntryNotFoundException, DuplicateTaskException, EntryConversionException {
         taskManager.editTask(update);
-        updateFilteredListToShowAll();
+        updateFilteredListToShowAllWithoutCompleted();
         indicateAddressBookChanged();
     }
 
     @Override
     public void markTask(Entry task) throws EntryNotFoundException {
         taskManager.markTask(task);
-        updateFilteredListToShowAll();
+        updateFilteredListToShowAllWithoutCompleted();
         indicateAddressBookChanged();
     }
 
     @Override
     public void unmarkTask(Entry task) throws EntryNotFoundException {
         taskManager.unmarkTask(task);
-        updateFilteredListToShowAll();
+        updateFilteredListToShowAllWithoutCompleted();
         indicateAddressBookChanged();
     }
 
     @Override
     public void tagTask(Entry taskToTag, UniqueTagList tagsToAdd) {
         taskManager.tagTask(taskToTag, tagsToAdd);
-        updateFilteredListToShowAll();
+        updateFilteredListToShowAllWithoutCompleted();
         indicateAddressBookChanged();
     }
 
     @Override
     public void untagTask(Entry taskToUntag, UniqueTagList tagsToRemove) throws EntryNotFoundException {
         taskManager.untagTask(taskToUntag, tagsToRemove);
-        updateFilteredListToShowAll();
+        updateFilteredListToShowAllWithoutCompleted();
         indicateAddressBookChanged();
     }
 
@@ -131,6 +131,12 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void updateFilteredListToShowAll() {
         filteredPersons.setPredicate(null);
+    }
+
+    @Override
+    public void updateFilteredListToShowAllWithoutCompleted() {
+        Predicate<Entry> predicate = e -> !e.isMarked();
+        filteredPersons.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Entry.java
+++ b/src/main/java/seedu/address/model/task/Entry.java
@@ -114,7 +114,7 @@ public abstract class Entry {
     /**
      * Returns true if Entry is marked as completed
      */
-    public final boolean isMarked() {
+    public boolean isMarked() {
         return isMarked.get();
     }
 

--- a/src/main/java/seedu/address/model/task/Event.java
+++ b/src/main/java/seedu/address/model/task/Event.java
@@ -119,4 +119,9 @@ public final class Event extends Entry{
         Date interpreted = Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
         return dateTime.format(DATE_TIME_FORMATTER);
     }
+
+    @Override
+    public boolean isMarked() {
+        return LocalDateTime.now().isAfter(endTime.get());
+    }
 }

--- a/src/main/java/seedu/address/ui/HelpList.java
+++ b/src/main/java/seedu/address/ui/HelpList.java
@@ -18,6 +18,8 @@ public class HelpList extends ListView<HelpList.HelpItem> {
     private static final String EDIT_HELP_TEXT = "edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]\n";
     private static final String ESCAPE_HELP = "CLOSE HELP";
     private static final String ESCAPE_HELP_TEXT = "<ESCAPE-KEY>";
+    private static final String LIST_COMPLETED_HELP = "LIST-COMPLETED";
+    private static final String LIST_COMPLETED_HELP_TEXT = "list-completed [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]";
     private static final String LIST_HELP = "LIST";
     private static final String LIST_HELP_TEXT = "list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]";
     private static final String TAG_HELP = "TAG";
@@ -57,6 +59,7 @@ public class HelpList extends ListView<HelpList.HelpItem> {
         data.add(new HelpItem(ADD_HELP, ADD_HELP_TEXT));
         data.add(new HelpItem(EDIT_HELP, EDIT_HELP_TEXT));
         data.add(new HelpItem(LIST_HELP, LIST_HELP_TEXT));
+        data.add(new HelpItem(LIST_COMPLETED_HELP, LIST_COMPLETED_HELP_TEXT));
         data.add(new HelpItem(TAG_HELP, TAG_HELP_TEXT));
         data.add(new HelpItem(UNTAG_HELP, UNTAG_HELP_TEXT));
         data.add(new HelpItem(DELETE_HELP, DELETE_HELP_TEXT));

--- a/src/main/java/seedu/address/ui/HelpList.java
+++ b/src/main/java/seedu/address/ui/HelpList.java
@@ -16,7 +16,7 @@ public class HelpList extends ListView<HelpList.HelpItem> {
             "CLOSE HELP",
             "ADD", "EDIT",
             "DELETE", "LIST",
-            "LIST-COMPLETED",
+            "LIST-ALL",
             "TAG", "UNTAG",
             "MARK", "UNMARK",
             "UNDO", "OPTION"};
@@ -27,7 +27,7 @@ public class HelpList extends ListView<HelpList.HelpItem> {
             "edit <task_id> [title/new title] [start/<start> end/<end>] [#<tags>...] [r/ <recurrence>] [desc/<description>]",
             "delete <task_id>",
             "list [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]",
-            "list-completed [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]",
+            "list-all [[keywords] [[after/<date>] [before/<date>] | [on/<date>]][#<tag_name> ...] [recurrence=<recurrence_value>] [desc=<description_value>]]",
             "tag <task_id> #<tag_name> [#<tag_name> ...]",
             "untag <task_id> #<tag_name> [#<tag_name> ...]",
             "mark <task_id>",

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -259,7 +259,7 @@ public class LogicManagerTest {
         model.addTask(toBeMarked);
         expectedAB.addTask(toBeMarked);
 
-        assertCommandBehavior(ListCommand.LIST_COMPLETED_COMMAND_WORD,
+        assertCommandBehavior(ListCommand.LIST_ALL_COMMAND_WORD,
             ListCommand.MESSAGE_SUCCESS,
             expectedAB,
             expectedList);
@@ -361,7 +361,7 @@ public class LogicManagerTest {
         List<Task> expectedList = helper.generateEntryList(p1, pTarget1, p2, pTarget2);
         helper.addToModel(model, fourPersons);
 
-        assertCommandBehavior(ListCommand.LIST_COMPLETED_COMMAND_WORD,
+        assertCommandBehavior(ListCommand.LIST_ALL_COMMAND_WORD,
                 ListCommand.MESSAGE_SUCCESS,
                 expectedAB,
                 expectedList);
@@ -626,7 +626,7 @@ public class LogicManagerTest {
         expectedAB.addTask(toBeMarkedCopy);
         
         model.addTask(alreadyMarked);
-        logic.execute(ListCommand.LIST_COMPLETED_COMMAND_WORD);
+        logic.execute(ListCommand.LIST_ALL_COMMAND_WORD);
 
         assertCommandBehavior("mark 1",
                 String.format(MarkCommand.MESSAGE_SUCCESS, alreadyMarked),
@@ -776,7 +776,7 @@ public class LogicManagerTest {
 
         model.addTask(toBeUnmarked);
         // command to undo
-        logic.execute(ListCommand.LIST_COMPLETED_COMMAND_WORD);
+        logic.execute(ListCommand.LIST_ALL_COMMAND_WORD);
         logic.execute("unmark 1");
         // execute command and verify result
         assertCommandBehavior("undo",
@@ -880,9 +880,9 @@ public class LogicManagerTest {
 
         // command to undo
         logic.execute(helper.generateAddCommand(task3));
-        logic.execute(ListCommand.LIST_COMPLETED_COMMAND_WORD); //non-undoable command.
+        logic.execute(ListCommand.LIST_ALL_COMMAND_WORD); //non-undoable command.
         logic.execute("mark 2");
-        logic.execute(ListCommand.LIST_COMPLETED_COMMAND_WORD); //non-undoable command.
+        logic.execute(ListCommand.LIST_ALL_COMMAND_WORD); //non-undoable command.
         logic.execute("delete 2");
 
         // Undo "delete 2"
@@ -1021,7 +1021,7 @@ public class LogicManagerTest {
 
         model.addTask(toBeUnmarked);
         // command to undo
-        logic.execute(ListCommand.LIST_COMPLETED_COMMAND_WORD);
+        logic.execute(ListCommand.LIST_ALL_COMMAND_WORD);
         logic.execute("unmark 1");
         logic.execute("undo");
         // execute command and verify result

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -282,7 +282,7 @@ public class LogicManagerTest {
     private void assertIndexNotFoundBehaviorForCommand(String commandWord) throws Exception {
         String expectedMessage = MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX;
         TestDataHelper helper = new TestDataHelper();
-        List<Task> entryList = helper.generateEntreList(2);
+        List<Task> entryList = helper.generateEntryList(2);
 
         // set AB state to 2 entries
         model.resetData(new TaskManager());
@@ -307,7 +307,7 @@ public class LogicManagerTest {
     @Test
     public void execute_delete_removesCorrectPerson() throws Exception {
         TestDataHelper helper = new TestDataHelper();
-        List<Task> threePersons = helper.generateEntreList(3);
+        List<Task> threePersons = helper.generateEntryList(3);
 
         TaskManager expectedAB = helper.generateTodoList(threePersons);
         expectedAB.removeEntry(threePersons.get(1));
@@ -1195,7 +1195,7 @@ public class LogicManagerTest {
          * @param taskManager The TaskManager to which the Persons will be added
          */
         void addToAddressBook(TaskManager taskManager, int numGenerated) throws Exception{
-            addToAddressBook(taskManager, generateEntreList(numGenerated));
+            addToAddressBook(taskManager, generateEntryList(numGenerated));
         }
 
         /**
@@ -1221,7 +1221,7 @@ public class LogicManagerTest {
          * @param model The model to which the Persons will be added
          */
         void addToModel(Model model, int numGenerated) throws Exception{
-            addToModel(model, generateEntreList(numGenerated));
+            addToModel(model, generateEntryList(numGenerated));
         }
 
         /**
@@ -1245,7 +1245,7 @@ public class LogicManagerTest {
         /**
          * Generates a list of Persons based on the flags.
          */
-        List<Task> generateEntreList(int numGenerated) throws Exception{
+        List<Task> generateEntryList(int numGenerated) throws Exception{
             List<Task> entries = new ArrayList<>();
             for(int i = 1; i <= numGenerated; i++){
                 entries.add(generateTask(i));

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -309,7 +309,7 @@ public class LogicManagerTest {
         TestDataHelper helper = new TestDataHelper();
         List<Task> threePersons = helper.generateEntreList(3);
 
-        TaskManager expectedAB = helper.generateAddressBook(threePersons);
+        TaskManager expectedAB = helper.generateTodoList(threePersons);
         expectedAB.removeEntry(threePersons.get(1));
         helper.addToModel(model, threePersons);
 
@@ -330,7 +330,7 @@ public class LogicManagerTest {
         Task p2 = helper.generateEntryWithTitle("KEYKEYKEY sduauo");
         
         List<Task> fourPersons = helper.generateEntryList(p1, pTarget1, p2, pTarget2);
-        TaskManager expectedAB = helper.generateAddressBook(fourPersons);
+        TaskManager expectedAB = helper.generateTodoList(fourPersons);
         List<Task> expectedList = helper.generateEntryList(p1, pTarget1, p2, pTarget2);
         helper.addToModel(model, fourPersons);
 
@@ -349,7 +349,7 @@ public class LogicManagerTest {
         Task p2 = helper.generateEntryWithTitle("KEYKEYKEY sduauo");
 
         List<Task> fourPersons = helper.generateEntryList(p1, pTarget1, p2, pTarget2);
-        TaskManager expectedAB = helper.generateAddressBook(fourPersons);
+        TaskManager expectedAB = helper.generateTodoList(fourPersons);
         List<Task> expectedList = helper.generateEntryList(pTarget1, pTarget2);
         helper.addToModel(model, fourPersons);
 
@@ -368,7 +368,7 @@ public class LogicManagerTest {
         Task p4 = helper.generateEntryWithTitle("KEy sduauo");
 
         List<Task> fourPersons = helper.generateEntryList(p3, p1, p4, p2);
-        TaskManager expectedAB = helper.generateAddressBook(fourPersons);
+        TaskManager expectedAB = helper.generateTodoList(fourPersons);
         List<Task> expectedList = fourPersons;
         helper.addToModel(model, fourPersons);
 
@@ -387,7 +387,7 @@ public class LogicManagerTest {
         Task p1 = helper.generateEntryWithTitle("sduauo");
 
         List<Task> fourPersons = helper.generateEntryList(pTarget1, p1, pTarget2, pTarget3);
-        TaskManager expectedAB = helper.generateAddressBook(fourPersons);
+        TaskManager expectedAB = helper.generateTodoList(fourPersons);
         List<Task> expectedList = helper.generateEntryList(pTarget1, pTarget2, pTarget3);
         helper.addToModel(model, fourPersons);
 
@@ -412,7 +412,7 @@ public class LogicManagerTest {
         helper.addToModel(model, helper.generateEntryList(t1));
 
         List<Task> expectedList = helper.generateEntryList(t1);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         
         assertCommandBehavior("tag 1 " + TAG_FLAG + "**", expectedMessage, expectedAB, expectedList);
     }
@@ -425,7 +425,7 @@ public class LogicManagerTest {
         
         Task t1Copy = helper.generateTask(1);
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         String expectedMessage = String.format(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         
         assertCommandBehavior("tag 1", expectedMessage, expectedAB, expectedList);
@@ -447,7 +447,7 @@ public class LogicManagerTest {
         t1Copy.addTags(tags);
         
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         String expectedMessage = String.format(TagCommand.MESSAGE_SUCCESS, tags, t1Copy);
         assertCommandBehavior(helper.generateTagCommand(tags, 1),
                 expectedMessage, expectedAB, expectedList);
@@ -468,7 +468,7 @@ public class LogicManagerTest {
         t1Copy.addTags(tags);
         
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         String expectedMessage = String.format(TagCommand.MESSAGE_SUCCESS, new UniqueTagList(tag3), t1Copy);
         assertCommandBehavior(helper.generateTagCommand(tags, 1),
                 expectedMessage, expectedAB, expectedList);
@@ -488,7 +488,7 @@ public class LogicManagerTest {
         t1Copy.addTags(tags);
         
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         String expectedMessage = String.format(TagCommand.MESSAGE_ALREADY_EXISTS, t1Copy);
         assertCommandBehavior(helper.generateTagCommand(tags, 1),
                 expectedMessage, expectedAB, expectedList);
@@ -509,7 +509,7 @@ public class LogicManagerTest {
         helper.addToModel(model, helper.generateEntryList(t1));
 
         List<Task> expectedList = helper.generateEntryList(t1);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         
         assertCommandBehavior("untag 1 " + TAG_FLAG + "**", expectedMessage, expectedAB, expectedList);
     }
@@ -522,7 +522,7 @@ public class LogicManagerTest {
         
         Task t1Copy = helper.generateTask(1);
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE);
         
         assertCommandBehavior("untag 1", expectedMessage, expectedAB, expectedList);
@@ -544,7 +544,7 @@ public class LogicManagerTest {
         t1Copy.removeTags(tags);
         
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         helper.addToAddressBook(expectedAB, new UniqueTagList(tag1));
 
         String expectedMessage = String.format(UntagCommand.MESSAGE_SUCCESS, new UniqueTagList(tag1), t1Copy);
@@ -564,7 +564,7 @@ public class LogicManagerTest {
         Task t1Copy = helper.generateTask(1);
         
         List<Task> expectedList = helper.generateEntryList(t1Copy);
-        TaskManager expectedAB = helper.generateAddressBook(expectedList);
+        TaskManager expectedAB = helper.generateTodoList(expectedList);
         String expectedMessage = String.format(UntagCommand.MESSAGE_NON_EXISTENT, t1Copy);
         assertCommandBehavior(helper.generateUntagCommand(tags, 1),
                 expectedMessage, expectedAB, expectedList);
@@ -1175,7 +1175,7 @@ public class LogicManagerTest {
         /**
          * Generates an TaskManager with auto-generated persons.
          */
-        TaskManager generateAddressBook(int numGenerated) throws Exception{
+        TaskManager generateTodoList(int numGenerated) throws Exception{
             TaskManager taskManager = new TaskManager();
             addToAddressBook(taskManager, numGenerated);
             return taskManager;
@@ -1184,7 +1184,7 @@ public class LogicManagerTest {
         /**
          * Generates an TaskManager based on the list of Persons given.
          */
-        TaskManager generateAddressBook(List<Task> persons) throws Exception{
+        TaskManager generateTodoList(List<Task> persons) throws Exception{
             TaskManager taskManager = new TaskManager();
             addToAddressBook(taskManager, persons);
             return taskManager;


### PR DESCRIPTION
Fixes #115 
Fixes #54 

Changes:
- Automatically hides completed tasks
- Added `list-completed` command to explicitly opt-in
- Reformat the User Guide (removed all the ugly indentation `> `)

Future improvements:
- We can use `l` as shortcut for `list` and `lc` as shortcut for `list-completed`