### PR TITLE
Mark unmark list refresh

### DIFF
--- a/src/main/java/seedu/priorityq/model/ModelManager.java
+++ b/src/main/java/seedu/priorityq/model/ModelManager.java
@@ -94,14 +94,12 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void markTask(Entry task) throws EntryNotFoundException {
         taskManager.markTask(task);
-        updateFilteredListToShowAllWithoutCompleted();
         indicateTaskManagerChanged();
     }
 
     @Override
     public void unmarkTask(Entry task) throws EntryNotFoundException {
         taskManager.unmarkTask(task);
-        updateFilteredListToShowAllWithoutCompleted();
         indicateTaskManagerChanged();
     }
 

--- a/src/test/java/seedu/priorityq/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/priorityq/logic/LogicManagerTest.java
@@ -626,7 +626,7 @@ public class LogicManagerTest {
         assertCommandBehavior("mark 1",
                 String.format(MarkCommand.MESSAGE_SUCCESS, alreadyMarked),
                 expectedTM,
-                new ArrayList<>());
+                expectedTM.getTaskList());
     }
 
     @Test
@@ -777,7 +777,7 @@ public class LogicManagerTest {
         assertCommandBehavior("undo",
                 String.format(UnmarkCommand.MESSAGE_UNDO_SUCCESS, toBeUnmarked),
                 expectedTM,
-                new ArrayList<>());
+                expectedTM.getTaskList());
     }
 
     @Test


### PR DESCRIPTION
Prevents the model from resetting the filtered list to list all when mark and unmark commands are executed.